### PR TITLE
Event fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ To use the methods available, access the editor instance from your froalaOptions
 function myCtrl($scope){
 	$scope.myHtml = "";
 	$scope.froalaOptions = {
-		toolbarButtons : ["bold", "italic", "underline", "|", "align", "formatOL", "formatUL"]
+		toolbarButtons : ["bold", "italic", "underline", "|", "align", "formatOL", "formatUL"],
+		events: {
+			'froalaEditor.initialized': function () {
+				// Use the methods like this.
+				$scope.froalaOptions.froalaEditor('selection.get');
+			}
+		}
 	}
-
-//Use the methods like this
-$scope.froalaOptions.froalaEditor("selection.get");
 ```
 ###Events
  Events can be passed in with the options, with a key events and object where the key is the event name and the value is the callback function.
@@ -135,7 +138,7 @@ Clone the Git [Angular-Froala](https://github.com/froala/angular-froala) reposit
     $ bower install
 
 #### Running tests
-Each contribution to the project should come with its set of unit tests thus ensuring that the new behaviour will not be altered by subsequent commits. 
+Each contribution to the project should come with its set of unit tests thus ensuring that the new behaviour will not be altered by subsequent commits.
 So, before each commit to the repository, run the tests by running the following grunt task:
 
     $ grunt test

--- a/demo/app.js
+++ b/demo/app.js
@@ -1,26 +1,33 @@
 	// add the module with global defaults for froala
 	var myApp = angular.module('myApp', ['ngSanitize', 'froala']).
-		value('froalaConfig', {
-			toolbarInline: false,
-			placeholderText: "Edit Your Content Here!"
-		});
+	value('froalaConfig', {
+		toolbarInline: false,
+		placeholderText: 'Edit Your Content Here!'
+	});
 
 	// create the controller and inject Angular's $scope
 	myApp.controller('mainController', function($scope) {
 
 		$scope.titleOptions = {
-			placeholderText : 'Add a Title',
+			placeholderText: 'Add a Title',
 			charCounterCount: false,
-			toolbarInline: true
+			toolbarInline: true,
+			events: {
+				'froalaEditor.initialized': function() {
+					console.log('initialized')
+				}
+			}
 		};
 
-    $scope.initialize = function (initControls) {
-      $scope.initControls = initControls;
-      $scope.deleteAll = function() {initControls.getEditor()('html.set', '');};
-    };
+		$scope.initialize = function(initControls) {
+			$scope.initControls = initControls;
+			$scope.deleteAll = function() {
+				initControls.getEditor()('html.set', '');
+			};
+		};
 
 		$scope.myTitle = '<span style="font-family: Verdana,Geneva,sans-serif; font-size: 30px;">My Document\'s Title</span><span style="font-size: 18px;"></span></span>';
-		$scope.sample2Text = "";
-    $scope.sample3Text = "";
+		$scope.sample2Text = '';
+		$scope.sample3Text = '';
 
 	});

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,6 +4,8 @@
 <html ng-app="myApp">
 
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0"/>
   <script src="../bower_components/jquery/dist/jquery.min.js"></script>
 
   <!-- Include Font Awesome. -->

--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -27,7 +27,7 @@ directive('froala', ['froalaConfig', function (froalaConfig) {
             scope.initMode = attrs.froalaInit ? MANUAL : AUTOMATIC;
 
             ctrl.init = function () {
-                ctrl.listeningEvents = ["keyup", 'froalaEditor'];
+                ctrl.listeningEvents = ['froalaEditor'];
                 if (!attrs.id) {
                     // generate an ID if not present
                     attrs.$set('id', 'froala-' + generatedIds++);
@@ -54,15 +54,17 @@ directive('froala', ['froalaConfig', function (froalaConfig) {
             ctrl.createEditor = function () {
                 if (!ctrl.editorInitialized) {
                     ctrl.options = angular.extend({}, froalaConfig, scope.froalaOptions);
-                    ctrl.froalaElement = element.froalaEditor(ctrl.options).data('froala.editor').$el;
-                    ctrl.froalaEditor = angular.bind(element, element.froalaEditor);
 
-                    //Register events provided in the options
+                    // Register events provided in the options
+                    // Registering events before initializing the editor will bind the initialized event correctly.
                     for (var eventName in ctrl.options.events) {
                         if (ctrl.options.events.hasOwnProperty(eventName)) {
                             ctrl.registerEventsWithCallbacks(eventName, ctrl.options.events[eventName]);
                         }
                     }
+
+                    element.froalaEditor(ctrl.options);
+                    ctrl.froalaEditor = angular.bind(element, element.froalaEditor);
                     ctrl.initListeners();
 
                     //assign the froala instance to the options object to make methods available in parent scope
@@ -75,10 +77,6 @@ directive('froala', ['froalaConfig', function (froalaConfig) {
             };
 
             ctrl.initListeners = function () {
-                ctrl.froalaElement.on('keyup', function () {
-                    ctrl.updateModelView();
-                });
-
                 element.on('froalaEditor.contentChanged', function () {
                     ctrl.updateModelView();
                 });

--- a/test/angular-froala.spec.js
+++ b/test/angular-froala.spec.js
@@ -99,29 +99,12 @@ describe("froala", function () {
         expect(element.attr('class')).toContain('ng-invalid');
     });
 
-    it('Registers the Key Up event', function () {
-        compileElement();
-
-        expect(froalaEditorOnStub.args[0][0]).toEqual('keyup');
-    });
-
     it('Destroys editor when directive is destroyed', function () {
         compileElement();
 
         $rootScope.$destroy();
 
         expect(froalaEditorStub.args[1][0]).toEqual('destroy');
-    });
-
-
-    it('Updates the model after a key is released', function () {
-        compileElement(function () {
-            froalaEditorStub.onSecondCall().returns('My String');
-        });
-
-        froalaEditorOnStub.callArgOn(1);
-
-        expect($rootScope.content).toEqual('My String');
     });
 
     it('Updates the model after the froala editor content has changed', function () {


### PR DESCRIPTION
1. We get lots of reports about the editor working slowly in Angular and after checking it further it appears the problem comes from the angular-froala binding to each `keyup` event to get the editor content and update model. Instead, it should do that only on `contentChanged` event.

2. The events should be set before initializing the editor to make sure we catch the `initialized` event all the time. This would also fix the issue #59.

3. Update README for calling events. #64.

@cgallarno @andrewattellwise @Whyves would love to hear your thoughts before merging this.