### PR TITLE
fix for contentChanged not triggering under specific circumstances

### DIFF
--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -44,6 +44,7 @@ value('froalaConfig', {})
                     element.froalaEditor('html.set', ngModel.$viewValue || '', true);
                     //This will reset the undo stack everytime the model changes externally. Can we fix this?
                     element.froalaEditor('undo.reset');
+                    element.froalaEditor('undo.saveStep');
                 };
 
                 ngModel.$isEmpty = function (value) {


### PR DESCRIPTION
@stefanneculai and I have identified that an issue with contentChanged not triggering when the editor initializes with an empty value, and then html.set is called to populate the editor without then calling undo.saveStep. This is a problem introduced into angular-froala in the $render function.