### PR TITLE
Give ability to pass options when editor instantiated manually

### DIFF
--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -53,10 +53,11 @@ value('froalaConfig', {})
                 };
             };
 
-            ctrl.createEditor = function () {
+            ctrl.createEditor = function (froalaInitOptions) {
                 ctrl.listeningEvents = ['froalaEditor'];
                 if (!ctrl.editorInitialized) {
-                    ctrl.options = angular.extend({}, defaultConfig, froalaConfig, scope.froalaOptions);
+                    froalaInitOptions = (froalaInitOptions || {});
+                    ctrl.options = angular.extend({}, defaultConfig, froalaConfig, scope.froalaOptions,froalaInitOptions);
 
                     if (ctrl.options.immediateAngularModelUpdate) {
                         ctrl.listeningEvents.push('keyup');

--- a/test/angular-froala.spec.js
+++ b/test/angular-froala.spec.js
@@ -297,12 +297,21 @@ describe("froala", function () {
 
     });
 
-		it('Sets the view to the value of the model', function () {
+	it('Sets the view to the value of the model', function () {
 				$rootScope.content = '<i>New Text</i>';
 
 				compileViewElement();
 				$rootScope.$digest();
 
       	expect(view.html()).toEqual("<i>New Text</i>");
-		});
+	});
+
+    it('Sets options when the editor is instantiated manually', function () {
+        createEditorInManualMode();
+
+        $rootScope.initControls.initialize({initOnClick: false});
+
+        expect(froalaEditorStub.called).toBeTruthy();
+        expect(froalaEditorStub.args[0][0].initOnClick).toBeFalsy();
+    });
 });


### PR DESCRIPTION
I have a problem when initialize manually the editor with options values that only can be set after an ajax request (to get necessary data), the problem is when I set the froalaOptions  after ajax request end, it keep using the default one, so I came up with this solution.

Anyway, is there existing solution for my case? 

