### PR TITLE
Fixed error regarding undo.reset

### DIFF
--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -43,8 +43,10 @@ value('froalaConfig', {})
                 ngModel.$render = function () {
                     element.froalaEditor('html.set', ngModel.$viewValue || '', true);
                     //This will reset the undo stack everytime the model changes externally. Can we fix this?
-                    element.froalaEditor('undo.reset');
-                    element.froalaEditor('undo.saveStep');
+                    if (ctrl.editorInitialized) {
+                        element.froalaEditor('undo.reset');
+                        element.froalaEditor('undo.saveStep');
+                    }
                 };
 
                 ngModel.$isEmpty = function (value) {
@@ -79,8 +81,16 @@ value('froalaConfig', {})
                         scope.froalaOptions.froalaEditor = ctrl.froalaEditor;
                     }
 
-                    ctrl.editorInitialized = ctrl.froalaEditor ? true : false;
+                    if (ctrl.options.initOnClick) {
+                        ctrl.registerEventsWithCallbacks('froalaEditor.initialized', function() {
+                            ctrl.editorInitialized = true;
+                        });
+                    } else {
+                        ctrl.editorInitialized = ctrl.froalaEditor ? true : false;
+                    }
                 }
+                
+                
             };
 
             ctrl.initListeners = function () {

--- a/test/angular-froala.spec.js
+++ b/test/angular-froala.spec.js
@@ -56,7 +56,7 @@ describe("froala", function () {
         if (scope.froalaOptions === undefined) {
             scope.froalaOptions = {};
         }
-        scope.froalaOptions.initOnClick = true;
+        scope.froalaOptions.disableRightClick = true;
         scope.content = '';
     };
 
@@ -88,7 +88,7 @@ describe("froala", function () {
         compileElement();
 
         expect(froalaEditorStub.args[0][0].placeholderText).toEqual('Placeholder');
-        expect(froalaEditorStub.args[0][0].initOnClick).toBeTruthy();
+        expect(froalaEditorStub.args[0][0].disableRightClick).toBeTruthy();
     });
 
     it('Uses default option values when no options are provided', function () {

--- a/test/angular-froala.spec.js
+++ b/test/angular-froala.spec.js
@@ -150,6 +150,7 @@ describe("froala", function () {
         });
 
         froalaEditorOnStub.callArgOn(1);
+        $rootScope.$digest();
 
         expect($rootScope.content).toEqual('My String');
     });
@@ -160,6 +161,7 @@ describe("froala", function () {
         });
 
         element.trigger('froalaEditor.contentChanged');
+        $rootScope.$digest();
 
         expect($rootScope.content).toEqual('My String');
     });


### PR DESCRIPTION
This error happens when the initOnClick option is set to true. In that case, delayed the initialized flag until the Froala editor tells us that it is ready.