### PR TITLE
Now waits for editor initialized event before sending commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 froala/*
+dist/*
 bower_components/*
 node_modules/*
 npm-debug.log

--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -41,19 +41,21 @@ value('froalaConfig', {})
 
                 //Instruct ngModel how to update the froala editor
                 ngModel.$render = function () {
-                    element.froalaEditor('html.set', ngModel.$viewValue || '', true);
-                    //This will reset the undo stack everytime the model changes externally. Can we fix this?
                     if (ctrl.editorInitialized) {
+                        element.froalaEditor('html.set', ngModel.$viewValue || '', true);
+                        //This will reset the undo stack everytime the model changes externally. Can we fix this?
                         element.froalaEditor('undo.reset');
                         element.froalaEditor('undo.saveStep');
                     }
                 };
 
                 ngModel.$isEmpty = function (value) {
-                  if (!value) return true;
+                    if (!value) {
+                        return true;
+                    }
 
-                  var isEmpty = element.froalaEditor('node.isEmpty', jQuery('<div>' + value + '</div>').get(0));
-                  return isEmpty;
+                    var isEmpty = element.froalaEditor('node.isEmpty', jQuery('<div>' + value + '</div>').get(0));
+                    return isEmpty;
                 };
             };
 
@@ -66,6 +68,11 @@ value('froalaConfig', {})
                     if (ctrl.options.immediateAngularModelUpdate) {
                         ctrl.listeningEvents.push('keyup');
                     }
+
+                    ctrl.registerEventsWithCallbacks('froalaEditor.initialized', function() {
+                        ctrl.editorInitialized = true;
+                        ngModel.$render();
+                    });
 
                     // Register events provided in the options
                     // Registering events before initializing the editor will bind the initialized event correctly.
@@ -83,17 +90,7 @@ value('froalaConfig', {})
                     if (scope.froalaOptions) {
                         scope.froalaOptions.froalaEditor = ctrl.froalaEditor;
                     }
-
-                    if (ctrl.options.initOnClick) {
-                        ctrl.registerEventsWithCallbacks('froalaEditor.initialized', function() {
-                            ctrl.editorInitialized = true;
-                        });
-                    } else {
-                        ctrl.editorInitialized = ctrl.froalaEditor ? true : false;
-                    }
                 }
-                
-                
             };
 
             ctrl.initListeners = function () {

--- a/test/angular-froala.spec.js
+++ b/test/angular-froala.spec.js
@@ -171,6 +171,7 @@ describe("froala", function () {
 
         $rootScope.content = '<i>New Text</i>';
         $rootScope.$digest();
+        element.trigger('froalaEditor.initialized');
 
         expect(froalaEditorStub.getCall(1).args[0]).toEqual('html.set');
         expect(froalaEditorStub.getCall(1).args[1]).toEqual('<i>New Text</i>');
@@ -219,9 +220,11 @@ describe("froala", function () {
         createEditorInManualMode();
 
         $rootScope.initControls.initialize();
+        element.trigger('froalaEditor.initialized');
+
         $rootScope.initControls.initialize();
 
-        expect(froalaEditorStub.callCount).toEqual(1);
+        expect(froalaEditorStub.callCount).toEqual(4); // 1 for creating editor and 3 after initialized event
     });
 
     it('Can re-initialize the editor after closing it', function () {


### PR DESCRIPTION
Newer versions of Froala editor spits out warning when trying to access methods before it is being fully initialized. Now prevents accessing those methods before editor is fully initialized. 