### PR TITLE
XSS vulnerability

### DIFF
--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -93,6 +93,9 @@
                 return true;
               }
 
+              // Clean the value content, keeping default htmlAllowedTags and htmlAllowedAttrs from froala configuration.
+              value = element.froalaEditor('clean.html', value, [], [], false);
+
               var isEmpty = element.froalaEditor('node.isEmpty', jQuery('<div>' + value + '</div>').get(0));
               return isEmpty;
             };

--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -1,3 +1,5 @@
+/*jshint -W034 */
+
 (function(window, angular, jQuery, undefined) {
   'use strict';
 
@@ -30,18 +32,18 @@
         require: 'ngModel',
         scope: scope,
         link: function(scope, element, attrs, ngModel) {
-          if (jQuery) element = jQuery(element);
+          if (jQuery) {
+            element = jQuery(element);
+          }
 
           var specialTag = false;
-          if (SPECIAL_TAGS.indexOf(element.prop("tagName").toLowerCase()) != -1) {
+          if (SPECIAL_TAGS.indexOf(element.prop("tagName").toLowerCase()) !== -1) {
             specialTag = true;
           }
 
           var ctrl = {
             editorInitialized: false
           };
-
-          var firstTime = false;
 
           scope.initMode = attrs.froalaInit ? MANUAL : AUTOMATIC;
 
@@ -65,7 +67,7 @@
                 // add tags on element
                 if (tags) {
                   for (var attr in tags) {
-                    if (tags.hasOwnProperty(attr) && attr != innerHtmlAttr) {
+                    if (tags.hasOwnProperty(attr) && attr !== innerHtmlAttr) {
                       element.attr(attr, tags[attr]);
                     }
                   }
@@ -103,12 +105,12 @@
               ctrl.options = angular.extend({}, defaultConfig, froalaConfig, scope.froalaOptions, froalaInitOptions);
 
               ctrl.registerEventsWithCallbacks('froalaEditor.initializationDelayed', function() {
-                ngModel.$render()
+                ngModel.$render();
               });
 
               ctrl.registerEventsWithCallbacks('froalaEditor.initialized', function () {
                 ctrl.editorInitialized = true;
-              })
+              });
 
               // Register events provided in the options
               // Registering events before initializing the editor will bind the initialized event correctly.
@@ -159,7 +161,7 @@
 
               for (var i = 0; i < attributeNodes.length; i++) {
                 var attrName = attributeNodes[i].name;
-                if (ctrl.options.angularIgnoreAttrs && ctrl.options.angularIgnoreAttrs.indexOf(attrName) != -1) {
+                if (ctrl.options.angularIgnoreAttrs && ctrl.options.angularIgnoreAttrs.indexOf(attrName) !== -1) {
                   continue;
                 }
                 attrs[attrName] = attributeNodes[i].value;

--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -94,8 +94,8 @@
               }
 
               if (ctrl.editorInitialized) {
- 		// Clean the value content, keeping default htmlAllowedTags and htmlAllowedAttrs from froala configuration.
-              	value = element.froalaEditor('clean.html', value, [], [], false);
+                // Clean the value content, keeping default htmlAllowedTags and htmlAllowedAttrs from froala configuration.
+                value = element.froalaEditor('clean.html', value, [], [], false);
                 return element.froalaEditor('node.isEmpty', jQuery('<div>' + value + '</div>').get(0));
               }
               return true;


### PR DESCRIPTION
The `ngModel.$isEmpty` function bypass the native froala security cleaning method, by executing the content of value with the `JQuery` function.

In my case, I just reuse the froala native html.clean method to fix it.

Like this:
```
ngModel.$isEmpty = function (value) {
	if (!value) {
		return true;
	}

	value = element.froalaEditor('clean.html', value, [], [], false);

	var isEmpty = element.froalaEditor('node.isEmpty', jQuery('<div>' + value + '</div>').get(0));
	return isEmpty;
};
```

Example of XSS injection concerned:
`Script URI scheme XSS test<img src="javascript:alert('XSS')">`

BTW, I have fixed some lint issues to and all your tests are down due to new JQuery version (3.3.1) by the froala dependencies.

AS the change is not invasive, I push it without testing it via grunt. I've made some tests by my side.