### PR TITLE
Check if element exists before updating model view

### DIFF
--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -150,6 +150,9 @@
           };
 
           ctrl.updateModelView = function() {
+            if (!element) {
+              return;
+            }
 
             var modelContent = null;
 


### PR DESCRIPTION
Hi,

We found a small issue with the model view update. Right now, when the `contentChanged` event fires, the model view is updated asynchronously. However, in come cases the update is performed after the element is destroyed, leading to the following error: 

```
TypeError: Cannot read property 'froalaEditor' of null
```

(caused here: https://github.com/froala/angular-froala/blob/master/src/angular-froala.js#L172)

In our case, this error happens when the user activates code view and then presses the back button of their browser.

I implemented a simple fix by checking if the element still exists before updating.

It would be great if this gets merged. Thanks!