### PR TITLE
Helps address #178

### DIFF
--- a/src/froala-sanitize.js
+++ b/src/froala-sanitize.js
@@ -333,7 +333,7 @@
         parseEndTag();
 
         function parseStartTag(tag, tagName, rest, unary) {
-            tagName = angular.lowercase(tagName);
+            tagName = tagName.toLowerCase();
             if (blockElements[tagName]) {
                 while (stack.last() && inlineElements[stack.last()]) {
                     parseEndTag("", stack.last());
@@ -368,7 +368,7 @@
 
         function parseEndTag(tag, tagName) {
             var pos = 0, i;
-            tagName = angular.lowercase(tagName);
+            tagName = tagName.toLowerCase();
             if (tagName) {
                 // Find the closest opened tag of the same type
                 for (pos = stack.length - 1; pos >= 0; pos--) {
@@ -485,8 +485,8 @@
         angular.forEach(styleArray, function (value) {
             var v = value.split(':');
             if (v.length === 2) {
-                var key = trim(angular.lowercase(v[0]));
-                value = trim(angular.lowercase(v[1]));
+                var key = trim(v[0].toLowerCase());
+                value = trim(v[1].toLowerCase());
                 if (
                     (key === 'color' || key === 'background-color') && (
                         value.match(/^rgb\([0-9%,\. ]*\)$/i) ||
@@ -556,7 +556,7 @@
         var out = angular.bind(buf, buf.push);
         return {
             start: function (tag, attrs, unary) {
-                tag = angular.lowercase(tag);
+                tag = tag.toLowerCase();
                 if (!ignore && specialElements[tag]) {
                     ignore = tag;
                 }
@@ -564,7 +564,7 @@
                     out('<');
                     out(tag);
                     angular.forEach(attrs, function (value, key) {
-                        var lkey = angular.lowercase(key);
+                        var lkey = key.toLowerCase();
                         var isImage = (tag === 'img' && lkey === 'src') || (lkey === 'background');
                         if ((lkey === 'style' && (value = validStyles(value)) !== '') || validCustomTag(tag, attrs, lkey, value) || validAttrs[lkey] === true &&
                             (uriAttrs[lkey] !== true || uriValidator(value, isImage))) {
@@ -579,7 +579,7 @@
                 }
             },
             end: function (tag) {
-                tag = angular.lowercase(tag);
+                tag = tag.toLowerCase();
                 if (!ignore && validElements[tag] === true) {
                     out('</');
                     out(tag);


### PR DESCRIPTION
Replace calls to angular.lowecase with String.prototype.toLowerCase()
as angular.lowercase has been removed in AngularJS 1.7

I have not updated any tests or linting as I wanted to reduce scope of impact (tests don't seem to be able to run anyway at the moment).