### PR TITLE
Angular1: Setting the content with ng-repeat, events are undefined #2354

### DIFF
--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -79,7 +79,7 @@
                 }
               }
               else {
-                if (ctrl.editorInitialized) {
+                if (ctrl.editorInitialized && ctrl.froalaEditor.html) {
                   // Set HTML.
                   ctrl.froalaEditor.html.set(ngModel.$viewValue || '')
                   //This will reset the undo stack everytime the model changes externally. Can we fix this?
@@ -126,16 +126,19 @@
           };
 
           ctrl.initListeners = function() {
-            if (ctrl.options.immediateAngularModelUpdate) {
-              ctrl.froalaEditor.events.on('keyup', function() {
-                scope.$evalAsync(ctrl.updateModelView);
-              });
-            }
-
-            ctrl.froalaEditor.events.on('contentChanged', function() {
-              scope.$evalAsync(ctrl.updateModelView);
-            });
-
+              // Check if we have events on the editor.
+              if (ctrl.froalaEditor.events) {
+                if (ctrl.options.immediateAngularModelUpdate) {
+                  ctrl.froalaEditor.events.on('keyup', function() {
+                    scope.$evalAsync(ctrl.updateModelView);
+                  });
+                }
+    
+                ctrl.froalaEditor.events.on('contentChanged', function() {
+                  scope.$evalAsync(ctrl.updateModelView);
+                });
+              }
+           
             if (ctrl.initEvents) {
               for (var i = 0; i < ctrl.initEvents; i++) {
                 ctrl.initEvents[i].call(ctrl.froalaEditor);


### PR DESCRIPTION
issue: https://github.com/froala-labs/froala-editor-js-2/issues/2354
Description: Angular1-Setting the content with ng-repeat, events are undefined #2354
Fix: provided undefined check for the events 