### PR TITLE
Feature/support multiple Froala instances that consume the same options object

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
   },
   "dependencies": {
     "coffee-script": "^1.12.7",
-    "froala-editor": "3.2.5-2"
+    "froala-editor": "3.2.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
   },
   "dependencies": {
     "coffee-script": "^1.12.7",
-    "froala-editor": "3.2.5-1"
+    "froala-editor": "3.2.5-2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
   },
   "dependencies": {
     "coffee-script": "^1.12.7",
-    "froala-editor": "3.2.5"
+    "froala-editor": "3.2.5-1"
   }
 }

--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -102,6 +102,8 @@
             if (!ctrl.editorInitialized) {
               froalaInitOptions = (froalaInitOptions || {});
               ctrl.options = angular.extend({}, defaultConfig, froalaConfig, scope.froalaOptions, froalaInitOptions);
+              // If a previous editor instance is still saved into these options, remove it, so we don't get circular reference errors.
+              delete ctrl.options.froalaEditor;
               ctrl.options.events = angular.extend({}, ctrl.options.events);
 
               ctrl.registerEventsWithCallbacks('initializationDelayed', function() {

--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -102,6 +102,7 @@
             if (!ctrl.editorInitialized) {
               froalaInitOptions = (froalaInitOptions || {});
               ctrl.options = angular.extend({}, defaultConfig, froalaConfig, scope.froalaOptions, froalaInitOptions);
+              ctrl.options.events = angular.extend({}, ctrl.options.events);
 
               ctrl.registerEventsWithCallbacks('initializationDelayed', function() {
                 ngModel.$render()


### PR DESCRIPTION
This worked in older versions of angular-froala. You couldn't easily access all of the instances using `$scope.froalaOptions.froalaEditor`, since they're sharing an options object, but if you didn't *need* to access all of the instances it worked perfectly well.

This patch makes that usage pattern work again with the current version of Froala (3.2.5) - it prevents "circular reference" errors when constructing a new Froala with preused options, and it prevents initialisation errors when trying to load up two or more Froala instances using the same options at the same time. It's also a really simple change. Should be no trouble to merge.