### PR TITLE
v3.3.2-3049

### DIFF
--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -101,7 +101,7 @@
           ctrl.createEditor = function(froalaInitOptions) {
             if (!ctrl.editorInitialized) {
               froalaInitOptions = (froalaInitOptions || {});
-              ctrl.options = angular.extend({}, defaultConfig, froalaConfig, scope.froalaOptions, froalaInitOptions);
+              ctrl.options = angular.extend({}, defaultConfig, froalaConfig, froalaInitOptions);
 
               ctrl.registerEventsWithCallbacks('initializationDelayed', function() {
                 ngModel.$render()


### PR DESCRIPTION
Fixed, The editor cannot be initialized for the second time with ng-if directive.

Ticket(s): https://github.com/froala-labs/froala-editor-js-2/issues/3049