### PR TITLE
bind correct this context to event

### DIFF
--- a/src/angular-froala.js
+++ b/src/angular-froala.js
@@ -111,7 +111,7 @@
               var initEvent = ctrl.options.events.initialized;
               if (!ctrl.options.events) ctrl.options.events = {};
               ctrl.options.events.initialized = function () {
-                initEvent && initEvent();
+                initEvent && initEvent.bind(this)();
                 ctrl.initListeners();
                 ctrl.editorInitialized = true;
                 ngModel.$render()


### PR DESCRIPTION
The angular froala implementation hooks into the initialized event and passes it on. but the editor context is missing.

According to [froala documentation](https://froala.com/wysiwyg-editor/docs/events/#initialized) you should be able to access the editor instance via `this` in most events.

```javascript
new FroalaEditor('.selector', {
  events: {
    'initialized': function () {
      // Do something here.
      // this is the editor instance.
      console.log(this);
    }
  }
});
```

Right now `this` is undefined but this PR will fix this issue
